### PR TITLE
test-only implementation for instrumentation tests

### DIFF
--- a/src/rules.scala
+++ b/src/rules.scala
@@ -246,6 +246,7 @@ object Plugin extends sbt.Plugin {
     uninstall               <<= uninstallTaskDef,
     test                    <<= testTaskDef,
     test                    <<= test dependsOn (compile in Android, install),
+    testOnly                <<= testOnlyTaskDef,
     run                     <<= runTaskDef( install
                                           , sdkPath
                                           , projectLayout


### PR DESCRIPTION
This is a proposal for a task that's implementing my feature request #138.

After using adb-shell manually for a few days, I realised that it would be more sensible to separate the test case selection from the installation process, because it allows to launch multiple cases without having to restart, so I used `android:install` before running test cases.
The task overwrites the default scalatest `test-only` task in the Android scope and accepts arguments that match the parameters of the `-e` switch to `am instrument`.

As I am unexperienced with sbt, I couldn't get everything right, you'll probably want to rewrite parts of it. I refactored and used the manifest generation routine from the test task def. Also, using the method to resolve inputs, like `(projectLayout, packageName...) map (layout, pkg...) ⇒` was unsuccessful – the block just wouldn't get executed, so I assigned all values manually.