### PR TITLE
Add explicit LD_LIBRARY_PATH to renderscript llvm command.

### DIFF
--- a/src/tasks.scala
+++ b/src/tasks.scala
@@ -836,7 +836,7 @@ object Tasks {
         "-o", (layout.bin / "renderscript" / "res" / "raw").getAbsolutePath) :+
           script.getAbsolutePath
 
-      val r = cmd !
+      val r = Process(cmd, None, "LD_LIBRARY_PATH" -> file(rs).getParent).!
 
       if (r != 0)
         sys.error("renderscript failed: " + r)


### PR DESCRIPTION
This solves a problem described here: https://code.google.com/p/android/issues/detail?id=58406.