### PR TITLE
Update renderscript task to also handle renderscript-v8 support library

### DIFF
--- a/sbt-test/android-sdk-plugin/renderscript-support-v8/build.sbt
+++ b/sbt-test/android-sdk-plugin/renderscript-support-v8/build.sbt
@@ -1,0 +1,7 @@
+import android.Keys._
+
+android.Plugin.androidBuildAar
+
+name := "renderscript-support-v8"
+
+platformTarget in Android := "android-21"

--- a/sbt-test/android-sdk-plugin/renderscript-support-v8/project.properties
+++ b/sbt-test/android-sdk-plugin/renderscript-support-v8/project.properties
@@ -1,0 +1,2 @@
+renderscript.target=18
+renderscript.support.mode=true

--- a/sbt-test/android-sdk-plugin/renderscript-support-v8/project/tests.scala
+++ b/sbt-test/android-sdk-plugin/renderscript-support-v8/project/tests.scala
@@ -1,0 +1,25 @@
+import sbt._
+
+object Tests {
+  def findInArchive(archive: File)(predicate: String => Boolean): Boolean = {
+    import java.io._
+    import java.util.zip._
+    val in = new ZipInputStream(new FileInputStream(archive))
+    val found = Stream.continually(in.getNextEntry) takeWhile (
+      _ != null) exists (e => predicate(e.getName))
+
+    in.close()
+    found
+  }
+
+  def listArchive(archive: File): Seq[String] = {
+    import java.io._
+    import java.util.zip._
+    val in = new ZipInputStream(new FileInputStream(archive))
+    val found = Stream.continually(in.getNextEntry) takeWhile (
+      _ != null) map (_.getName) toList
+
+    in.close()
+    found
+  }
+}

--- a/sbt-test/android-sdk-plugin/renderscript-support-v8/src/main/AndroidManifest.xml
+++ b/sbt-test/android-sdk-plugin/renderscript-support-v8/src/main/AndroidManifest.xml
@@ -3,10 +3,7 @@
       package="com.example.app"
       android:versionCode="1"
       android:versionName="1.0">
-    <uses-sdk android:minSdkVersion="17" android:targetSdkVersion="18"/>
-    <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-feature android:name="android.hardware.touchscreen"
-                  android:required="false"/>
+    <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="18"/>
 
     <application android:label="App Name (Use a String Resource)"
                  android:debuggable="true"

--- a/sbt-test/android-sdk-plugin/renderscript-support-v8/src/main/rs/sample/invert.rs
+++ b/sbt-test/android-sdk-plugin/renderscript-support-v8/src/main/rs/sample/invert.rs
@@ -1,0 +1,11 @@
+#pragma version(1)
+#pragma rs_fp_inprecise
+#pragma rs java_package_name(sample)
+
+uchar4 __attribute__((kernel)) invert(uchar4 in, uint32_t x, uint32_t y) {
+  uchar4 out = in;
+  out.r = 255 - in.r;
+  out.g = 255 - in.g;
+  out.b = 255 - in.b;
+  return out;
+}

--- a/sbt-test/android-sdk-plugin/renderscript-support-v8/test
+++ b/sbt-test/android-sdk-plugin/renderscript-support-v8/test
@@ -1,0 +1,12 @@
+> check-target-api
+> check-support-mode
+> android:package
+> android:package-aar
+$ exists target/android-bin/renderscript-support-v8-debug.apk
+$ exists target/android-bin/renderscript-support-v8.aar
+> check-apk-for-resource
+> check-aar-for-resource
+> check-aar-for-libs
+> check-apk-for-libs
+> last android:apkbuild
+> show list-apk

--- a/sbt-test/android-sdk-plugin/renderscript-support-v8/tests.sbt
+++ b/sbt-test/android-sdk-plugin/renderscript-support-v8/tests.sbt
@@ -1,0 +1,54 @@
+import android.Keys._
+import Tests._
+
+TaskKey[Unit]("check-target-api") := {
+  if ((rsTargetApi in Android).value != "18")
+    sys.error("Renderscript targetApi not equal to 18: " + (rsTargetApi in Android).value)
+}
+
+TaskKey[Unit]("check-support-mode") := {
+  if (!(rsSupportMode in Android).value)
+    sys.error("Renderscript support mode was not set from project.properties")
+}
+
+TaskKey[Unit]("check-apk-for-resource") <<= (apkFile in Android) map { a =>
+  val found = findInArchive(a) (_ == "res/raw/invert.bc")
+  if (!found) error("Renderscript resource not found in APK\n" + listArchive(a))
+}
+
+TaskKey[Unit]("check-aar-for-resource") <<= (packageAar in Android) map { a =>
+  val found = findInArchive(a) (_ == "res/raw/invert.bc")
+  if (!found) error("Renderscript resource not found in Aar\n" + listArchive(a))
+}
+
+val jniLibs = Seq( 
+  "x86/librs.invert.so",
+  "x86/librsjni.so",
+  "x86/libRSSupport.so",
+  "armeabi-v7a/librs.invert.so",
+  "armeabi-v7a/librsjni.so",
+  "armeabi-v7a/libRSSupport.so"
+)
+
+def checkLibsInArchive(a: File, libs: Seq[String]) = {
+  val entries = listArchive(a).toSet
+  libs foreach { lib =>
+    if (!entries.contains(lib)) error(s"Library: $lib missing in archive: $a")
+  }
+}
+
+TaskKey[Unit]("check-aar-for-libs") := { 
+  checkLibsInArchive((packageAar in Android).value, "libs/renderscript-v8.jar" +: (jniLibs.map("jni/" + _))) 
+}
+
+TaskKey[Unit]("check-apk-for-libs") := { 
+  checkLibsInArchive((apkFile in Android).value, jniLibs.map("lib/" + _))
+}
+
+TaskKey[Seq[String]]("list-apk") <<= (apkFile in Android) map { a =>
+  listArchive(a)
+}
+
+TaskKey[Seq[String]]("list-aar") <<= (packageAar in Android) map { a =>
+  listArchive(a)
+}

--- a/sbt-test/android-sdk-plugin/renderscript/test
+++ b/sbt-test/android-sdk-plugin/renderscript/test
@@ -1,8 +1,10 @@
+> check-target-api-equals-min
 > android:package
 > android:package-aar
 $ exists target/android-bin/renderscript-debug.apk
 $ exists target/android-bin/renderscript.aar
 > check-apk-for-resource
 > check-aar-for-resource
+> check-aar-no-libs
 > last android:apkbuild
 > show list-apk

--- a/sbt-test/android-sdk-plugin/renderscript/tests.sbt
+++ b/sbt-test/android-sdk-plugin/renderscript/tests.sbt
@@ -1,6 +1,11 @@
 import android.Keys._
 import Tests._
 
+TaskKey[Unit]("check-target-api-equals-min") := {
+  if ((rsTargetApi in Android).value != "17")
+    sys.error("Renderscript targetApi: " + (rsTargetApi in Android).value + " not equal to minSdkVersion")
+}
+
 TaskKey[Unit]("check-apk-for-resource") <<= (apkFile in Android) map { a =>
   val found = findInArchive(a) (_ == "res/raw/invert.bc")
   if (!found) error("Renderscript resource not found in APK\n" + listArchive(a))
@@ -9,6 +14,15 @@ TaskKey[Unit]("check-apk-for-resource") <<= (apkFile in Android) map { a =>
 TaskKey[Unit]("check-aar-for-resource") <<= (packageAar in Android) map { a =>
   val found = findInArchive(a) (_ == "res/raw/invert.bc")
   if (!found) error("Renderscript resource not found in Aar\n" + listArchive(a))
+}
+
+TaskKey[Unit]("check-aar-no-libs") <<= (packageAar in Android) map { a =>
+  val found = findInArchive(a) (_.contains("libs"))
+  if (found) error("Some library was included in aar\n" + listArchive(a))
+}
+
+TaskKey[Seq[String]]("list-apk") <<= (apkFile in Android) map { a =>
+  listArchive(a)
 }
 
 TaskKey[Seq[String]]("list-apk") <<= (apkFile in Android) map { a =>

--- a/src/keys.scala
+++ b/src/keys.scala
@@ -8,7 +8,7 @@ import java.io.File
 import java.util.Properties
 
 import com.android.builder.core.AndroidBuilder
-import com.android.sdklib.{IAndroidTarget,SdkManager}
+import com.android.sdklib.{BuildToolInfo, IAndroidTarget, SdkManager}
 import com.android.utils.ILogger
 
 import Dependencies._
@@ -97,6 +97,7 @@ object Keys {
   val builder = TaskKey[AndroidBuilder]("builder", "AndroidBuilder object")
   val packageRelease = TaskKey[File]("package-release", "create a release apk")
   val packageDebug = TaskKey[File]("package-debug", "create a debug apk")
+  val collectProjectJni = taskKey[Seq[File]]("collect project JNI folder names for packaging (without libs from dependencies)")
   val collectJni = TaskKey[Seq[File]]("collect-jni",
     "collect all JNI folder names for packaging")
   val collectResources = TaskKey[(File,File)]("collect-resources",
@@ -138,8 +139,8 @@ object Keys {
   val sdkLoader = TaskKey[SdkLoader]("sdk-loader",
     "Internal android SDK loader")
   val sdkPath = SettingKey[String]("sdk-path", "Path to the Android SDK")
-  val sdkManager = TaskKey[SdkManager]("sdk-manager",
-    "Android SdkManager object")
+  val sdkManager = TaskKey[SdkManager]("sdk-manager", "Android SdkManager object")
+  val buildTools = taskKey[BuildToolInfo]("Android build tools")
   val platformTarget = SettingKey[String]("platform-target",
     "target API level as described by 'android list targets' (the ID string)")
   val platform = TaskKey[IAndroidTarget]("platform",
@@ -158,8 +159,11 @@ object Keys {
   val ndkBuild = TaskKey[Seq[File]]("ndk-build",
     "android ndk-build task, builds all auto-library project's ndk as well")
   val aidl = TaskKey[Seq[File]]("aidl", "android aidl source-gen task")
-  val renderscript = TaskKey[Seq[File]]("renderscript",
-    "android renderscript source-gen task")
+  val rsTargetApi = settingKey[String]("renderscript target api, default: minSdkVersion")
+  val rsSupportMode = settingKey[Boolean]("renderscript support mode, default: false")
+  val rsOptimLevel = settingKey[Int]("renderscript optimization level, default: 3")
+  val rsBinPath = settingKey[File]("renderscript output directory")
+  val renderscript = TaskKey[Seq[File]]("renderscript", "android renderscript source-gen task")
   val dex = TaskKey[File]("dex", "run bytecode dexer")
   val dexInputs = TaskKey[(Boolean,Seq[File])]("dex-inputs", "input jars to dex")
   val dexMaxHeap = SettingKey[String]("dex-max-heap",


### PR DESCRIPTION
Reimplemented renderscript task to use new RenderscriptProcessor tool.
Added handling for renderscript support library, and proper renderscript targetApi parameter (defaults to min sdk version, and can be changed in project.properties, as described here: https://code.google.com/p/android/issues/detail?id=40487).
Also added generated jni libs to packageAar (only libs from current project and renderscript, no transitive dependencies).

I've been using newer syntax for tasks: `val renderscriptTaskDef = Def.task {` instead of map, is that a problem?
In general: is there any specific reason why you keep using <<= with `map`? 
What do you think about refactoring with new syntax and splitting stuff into smaller files (for example : renderscriptKeys, renderscriptTasks, etc.)?