### PR TITLE
Updated Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,9 +379,8 @@ found on the #sbt-android IRC channel on Freenode
 * IDE integration
   * The primary IDE recommendation is IntelliJ, not Android Studio
     nor Eclipse.
-  * When loading a project into IntelliJ, it is required that the `SBT`
-    and `Scala` plugins are installed; the `SBT` plugin allows replacing the
-    default `Make` builder with sbt, enabling seamless builds from the IDE.
+  * When loading a project into IntelliJ, it is required that the `Android`
+    and `Scala` plugins are installed
   * The best practice is to set the IDE's run task to invoke sbt
     `android:package` instead of `Make`; this is found under the Run
     Configurations


### PR DESCRIPTION
The SBT plug-in is no longer required as it is included in the Scala plug-in. Also the Android plug-in is necessary or else IDEA won't actually show any file in the imported project. See http://stackoverflow.com/questions/29719394/how-to-get-intellij-idea-14-working-with-scala-on-android-sbt for details.