### PR TITLE
checkAars task

### DIFF
--- a/src/dependencies.scala
+++ b/src/dependencies.scala
@@ -121,6 +121,29 @@ object Dependencies {
     }
   }
 
+  case class LibEquals[A <: AndroidLibrary](lib: A)
+  {
+    override def equals(other: Any) = {
+      (lib, other) match {
+        case (l @ AarLibrary(_), LibEquals(r @ AarLibrary(_))) ⇒
+          l.moduleID == r.moduleID
+        case (l @ LibraryProject(_), LibEquals(r @ LibraryProject(_))) ⇒
+          l.path == r.path
+        case _ ⇒ false
+      }
+    }
+  }
+
+  implicit class LibrarySeqOps[A <: AndroidLibrary](libs: Seq[A])
+  {
+    def distinctLibs = {
+      libs
+        .map(LibEquals.apply)
+        .distinct
+        .map(_.lib)
+    }
+  }
+
   object LibraryProject {
     def apply(base: File): LibraryProject = LibraryProject(ProjectLayout(base))
   }

--- a/src/dependencies.scala
+++ b/src/dependencies.scala
@@ -176,20 +176,20 @@ object Dependencies {
 
   implicit class ModuleIDOps(id: ModuleID)
   {
-    def revCovers(other: String) = {
-      def partCovers(p: (String, String)) = p._1 == p._2 || p._1 == "+"
+    def revMatches(other: String) = {
+      def partMatches(p: (String, String)) = p._1 == p._2 || p._1 == "+"
       val parts = id.revision.toString.split('.')
       val otherParts = other.toString.split('.')
-      val partsCover = parts zip(otherParts) forall(partCovers)
-      partsCover && (
+      val partsMatch = parts zip(otherParts) forall(partMatches)
+      partsMatch && (
         parts.length == otherParts.length ||
         (parts.length < otherParts.length) && parts.lastOption.exists(_ == "+")
       )
     }
 
-    def covers(other: ModuleID) = {
+    def matches(other: ModuleID) = {
       id.organization == other.organization && id.name == other.name &&
-        revCovers(other.revision)
+        revMatches(other.revision)
     }
   }
 
@@ -201,12 +201,12 @@ object Dependencies {
     def deps = resolved map(_.dependencies) getOrElse(Nil) map(_.project)
 
     def deepDeps: Seq[ProjectRef] =
-      ((deps map(_.deepDeps) flatten) :+ project).distinct
+      ((deps flatMap(_.deepDeps)) :+ project).distinct
 
     def dependsOnAar(aar: AarLibrary) = {
       (sbt.Keys.libraryDependencies in project)
         .get(struct.data)
-        .exists(_.find(_.covers(aar.moduleID)).isDefined)
+        .exists(_.exists(_.covers(aar.moduleID)))
     }
   }
 }

--- a/src/dependencies.scala
+++ b/src/dependencies.scala
@@ -173,5 +173,41 @@ object Dependencies {
         deps map { x => x: ClasspathDep[ProjectReference] }:_*)
     }
   }
+
+  implicit class ModuleIDOps(id: ModuleID)
+  {
+    def revCovers(other: String) = {
+      def partCovers(p: (String, String)) = p._1 == p._2 || p._1 == "+"
+      val parts = id.revision.toString.split('.')
+      val otherParts = other.toString.split('.')
+      val partsCover = parts zip(otherParts) forall(partCovers)
+      partsCover && (
+        parts.length == otherParts.length ||
+        (parts.length < otherParts.length) && parts.lastOption.exists(_ == "+")
+      )
+    }
+
+    def covers(other: ModuleID) = {
+      id.organization == other.organization && id.name == other.name &&
+        revCovers(other.revision)
+    }
+  }
+
+  implicit class ProjectRefOps(project: ProjectRef)
+  (implicit struct: sbt.BuildStructure)
+  {
+    def resolved = Project.getProject(project, struct)
+
+    def deps = resolved map(_.dependencies) getOrElse(Nil) map(_.project)
+
+    def deepDeps: Seq[ProjectRef] =
+      ((deps map(_.deepDeps) flatten) :+ project).distinct
+
+    def dependsOnAar(aar: AarLibrary) = {
+      (sbt.Keys.libraryDependencies in project)
+        .get(struct.data)
+        .exists(_.find(_.covers(aar.moduleID)).isDefined)
+    }
+  }
 }
 // vim: set ts=2 sw=2 et:

--- a/src/keys.scala
+++ b/src/keys.scala
@@ -140,6 +140,7 @@ object Keys {
     "android library projects to reference, must be built separately") in Android
   val libraryProject = SettingKey[Boolean]("library-project",
     "setting indicating whether or not this is a library project") in Android
+  val checkAars = TaskKey[Unit]("check-aars", "check validity of aar deps") in Android
 
   // manifest-related keys
   val applicationId = TaskKey[String]("application-id",

--- a/src/resources.scala
+++ b/src/resources.scala
@@ -18,6 +18,8 @@ import language.postfixOps
 
 import BuildOutput._
 
+import Dependencies.LibrarySeqOps
+
 object Resources {
 
   def doCollectResources( bldr: AndroidBuilder
@@ -225,26 +227,11 @@ object Resources {
     bldr.processResources(aaptCommand, true)
   }
 
-  case class LibEquals(lib: AndroidLibrary)
-  {
-    override def equals(other: Any) = {
-      (lib, other) match {
-        case (l @ AarLibrary(_), LibEquals(r @ AarLibrary(_))) ⇒
-          l.moduleID == r.moduleID
-        case (l @ LibraryProject(_), LibEquals(r @ LibraryProject(_))) ⇒
-          l.path == r.path
-        case _ ⇒ false
-      }
-    }
-  }
-
   def collectdeps(libs: Seq[AndroidLibrary]): Seq[AndroidLibrary] = {
     libs
       .map(_.getDependencies.asScala)
       .flatMap(collectdeps)
       .++(libs)
-      .map(LibEquals.apply)
-      .distinct
-      .map(_.lib)
+      .distinctLibs
   }
 }

--- a/src/rules.scala
+++ b/src/rules.scala
@@ -549,6 +549,7 @@ object Plugin extends sbt.Plugin {
     collectResources        <<= collectResourcesTaskDef,
     collectResources        <<= collectResources dependsOn renderscript,
     collectResources        <<= collectResources dependsOn resValuesGenerator,
+    collectResources        <<= collectResources dependsOn checkAars,
     shrinkResources          := false,
     resourceShrinker        <<= resourceShrinkerTaskDef,
     packageResources        <<= packageResourcesTaskDef,

--- a/src/rules.scala
+++ b/src/rules.scala
@@ -32,6 +32,7 @@ import Keys.Internal._
 import Tasks._
 import Commands._
 import BuildOutput._
+import Dependencies.LibrarySeqOps
 
 object Plugin extends sbt.Plugin {
 
@@ -105,7 +106,10 @@ object Plugin extends sbt.Plugin {
         compile in Compile <<= compile in Compile dependsOn(
           packageT in Compile in p),
         localProjects += LibraryProject((projectLayout in p).value),
-        localProjects <++= localProjects in p
+        localProjects := {
+          ((localProjects).value ++
+            (localProjects in p).value).distinctLibs
+        }
       )
     }
   }

--- a/src/rules.scala
+++ b/src/rules.scala
@@ -456,6 +456,7 @@ object Plugin extends sbt.Plugin {
     libraryProjects          := localProjects.value ++ apklibs.value ++ aars.value,
     libraryProject          <<= properties { p =>
       Option(p.getProperty("android.library")) exists { _.equals("true") } },
+    checkAars               <<= checkAarsTaskDef,
     dexInputs               <<= dexInputsTaskDef,
     dexAggregate            <<= dexAggregateTaskDef,
     manifestAggregate       <<= manifestAggregateTaskDef,

--- a/src/tasks.scala
+++ b/src/tasks.scala
@@ -260,6 +260,48 @@ object Tasks {
     }
   }
 
+  val duplicateAars = Def.task {
+    Resources
+      .collectdeps(libraryProjects.value)
+      .collect { case a @ AarLibrary(_) ⇒ a }
+      .groupBy(_.moduleID.name)
+      .filter(_._2.length > 1)
+  }
+
+  val checkAarsTaskDef = Def.task {
+    implicit val log = streams.value.log
+    implicit val struct = buildStructure.value
+    val deps = thisProjectRef.value.deepDeps
+    def revDependents(aar: AarLibrary) = deps.filter(_.dependsOnAar(aar))
+    def pkgDependents(data: (String, Seq[AarLibrary])) = {
+      (data._1, data._2, data._2 map(revDependents))
+    }
+    val broken = duplicateAars.value
+    if (broken.isEmpty) log.info("All aar deps are consistent")
+    else {
+      log.warn("You have duplicate aar deps with different versions:")
+      broken
+        .map(pkgDependents)
+        .foreach { case (name, aars, dpd) ⇒
+          reportIncompatibleAars(name, aars, dpd)
+        }
+    }
+  }
+
+  def reportIncompatibleAars(name: String, aars: Seq[AarLibrary], dependents: Seq[Seq[ProjectRef]])
+  (implicit log: Logger, struct: sbt.BuildStructure) = {
+    log.warn(s"$name:")
+    aars zip dependents foreach { case (aar, dpd) ⇒
+      val sourceDesc =
+        if(dpd.isEmpty) "as transitive dep"
+        else {
+          val sourcePaths = dpd map(_.project) mkString(", ")
+          s"specified in $sourcePaths"
+        }
+      log.warn(s" * ${aar.moduleID.revision} $sourceDesc")
+    }
+  }
+
   val typedResourcesGeneratorTaskDef = ( typedResources
                                        , rGenerator
                                        , packageForR

--- a/src/tasks.scala
+++ b/src/tasks.scala
@@ -277,7 +277,7 @@ object Tasks {
       (data._1, data._2, data._2 map(revDependents))
     }
     val broken = duplicateAars.value
-    if (broken.isEmpty) log.info("All aar deps are consistent")
+    if (broken.isEmpty) log.debug("All aar deps are consistent")
     else {
       log.warn("You have duplicate aar deps with different versions:")
       broken


### PR DESCRIPTION
collect all AarLibrary deps and determines duplicates with different versions

searches the complete sbt project dep tree for the source of the duplicate depspecs