### PR TITLE
Alt check aars

### DIFF
--- a/src/dependencies.scala
+++ b/src/dependencies.scala
@@ -121,6 +121,29 @@ object Dependencies {
     }
   }
 
+  case class LibEquals[A <: AndroidLibrary](lib: A)
+  {
+    override def equals(other: Any) = {
+      (lib, other) match {
+        case (l @ AarLibrary(_), LibEquals(r @ AarLibrary(_))) ⇒
+          l.moduleID == r.moduleID
+        case (l @ LibraryProject(_), LibEquals(r @ LibraryProject(_))) ⇒
+          l.path.getCanonicalFile == r.path.getCanonicalFile
+        case _ ⇒ false
+      }
+    }
+  }
+
+  implicit class LibrarySeqOps[A <: AndroidLibrary](libs: Seq[A])
+  {
+    def distinctLibs = {
+      libs
+        .map(LibEquals.apply)
+        .distinct
+        .map(_.lib)
+    }
+  }
+
   object LibraryProject {
     def apply(base: File): LibraryProject = LibraryProject(ProjectLayout(base))
   }
@@ -148,6 +171,45 @@ object Dependencies {
     def androidBuildWith(deps: ProjectReference*): Project = {
       project.settings(Plugin.androidBuild ++ Plugin.buildWith(deps:_*):_*) dependsOn (
         deps map { x => x: ClasspathDep[ProjectReference] }:_*)
+    }
+  }
+
+  implicit class ModuleIDOps(id: ModuleID)
+  {
+    def revMatches(other: String) = {
+      def partMatches(p: (String, String)) = p._1 == p._2 || p._1 == "+"
+      val parts = id.revision.split('.')
+      val otherParts = other.split('.')
+      val partsMatch = parts zip(otherParts) forall(partMatches)
+      partsMatch && (
+        parts.length == otherParts.length ||
+        (parts.length < otherParts.length) && parts.lastOption.exists(_ == "+")
+      )
+    }
+
+    def matches(other: ModuleID) = {
+      id.organization == other.organization && id.name == other.name &&
+        revMatches(other.revision)
+    }
+  }
+
+  implicit class ProjectRefOps(project: ProjectRef)
+  (implicit struct: BuildStructure)
+  {
+    def resolved = Project.getProject(project, struct)
+
+    def deps = resolved map(_.dependencies) getOrElse(Nil) map(_.project)
+
+    def deepDeps: Seq[ProjectRef] =
+      ((deps flatMap(_.deepDeps)) :+ project).distinct
+
+    def libraryDependencies =
+      (sbt.Keys.libraryDependencies in project)
+        .get(struct.data)
+        .getOrElse(Nil)
+
+    def dependsOn(id: ModuleID) = {
+      libraryDependencies exists(_.matches(id))
     }
   }
 }

--- a/src/keys.scala
+++ b/src/keys.scala
@@ -140,6 +140,7 @@ object Keys {
     "android library projects to reference, must be built separately") in Android
   val libraryProject = SettingKey[Boolean]("library-project",
     "setting indicating whether or not this is a library project") in Android
+  val checkAars = TaskKey[Unit]("check-aars", "check validity of aar deps") in Android
 
   // manifest-related keys
   val applicationId = TaskKey[String]("application-id",

--- a/src/resources.scala
+++ b/src/resources.scala
@@ -18,6 +18,8 @@ import language.postfixOps
 
 import BuildOutput._
 
+import Dependencies.LibrarySeqOps
+
 object Resources {
 
   def doCollectResources( bldr: AndroidBuilder
@@ -225,26 +227,11 @@ object Resources {
     bldr.processResources(aaptCommand, true)
   }
 
-  case class LibEquals(lib: AndroidLibrary)
-  {
-    override def equals(other: Any) = {
-      (lib, other) match {
-        case (l @ AarLibrary(_), LibEquals(r @ AarLibrary(_))) ⇒
-          l.moduleID == r.moduleID
-        case (l @ LibraryProject(_), LibEquals(r @ LibraryProject(_))) ⇒
-          l.path == r.path
-        case _ ⇒ false
-      }
-    }
-  }
-
   def collectdeps(libs: Seq[AndroidLibrary]): Seq[AndroidLibrary] = {
     libs
       .map(_.getDependencies.asScala)
       .flatMap(collectdeps)
       .++(libs)
-      .map(LibEquals.apply)
-      .distinct
-      .map(_.lib)
+      .distinctLibs
   }
 }

--- a/src/rules.scala
+++ b/src/rules.scala
@@ -32,6 +32,7 @@ import Keys.Internal._
 import Tasks._
 import Commands._
 import BuildOutput._
+import Dependencies.LibrarySeqOps
 
 object Plugin extends sbt.Plugin {
 
@@ -105,7 +106,10 @@ object Plugin extends sbt.Plugin {
         compile in Compile <<= compile in Compile dependsOn(
           packageT in Compile in p),
         localProjects += LibraryProject((projectLayout in p).value),
-        localProjects <++= localProjects in p
+        localProjects := {
+          ((localProjects).value ++
+            (localProjects in p).value).distinctLibs
+        }
       )
     }
   }
@@ -452,6 +456,7 @@ object Plugin extends sbt.Plugin {
     libraryProjects          := localProjects.value ++ apklibs.value ++ aars.value,
     libraryProject          <<= properties { p =>
       Option(p.getProperty("android.library")) exists { _.equals("true") } },
+    checkAars               <<= checkAarsTaskDef,
     dexInputs               <<= dexInputsTaskDef,
     dexAggregate            <<= dexAggregateTaskDef,
     manifestAggregate       <<= manifestAggregateTaskDef,
@@ -544,6 +549,7 @@ object Plugin extends sbt.Plugin {
     collectResources        <<= collectResourcesTaskDef,
     collectResources        <<= collectResources dependsOn renderscript,
     collectResources        <<= collectResources dependsOn resValuesGenerator,
+    collectResources        <<= collectResources dependsOn checkAars,
     shrinkResources          := false,
     resourceShrinker        <<= resourceShrinkerTaskDef,
     packageResources        <<= packageResourcesTaskDef,


### PR DESCRIPTION
third attempt at an aars checker that uses only `transitiveLibs` and the update report of the current project instead of the whole project tree to search for dupes.