### PR TITLE
un-disable copyResources

### DIFF
--- a/src/rules.scala
+++ b/src/rules.scala
@@ -229,7 +229,6 @@ object Plugin extends sbt.Plugin {
         }) map (_.getAbsoluteFile)
       }.taskValue
     ),
-    copyResources      := { Seq.empty },
     packageT          <<= packageT dependsOn compile,
     javacOptions      <<= ( javacOptions
                           , builder


### PR DESCRIPTION
it seems that this has no more significance, while it prevents managed resources to be visible in the test configuration.