### PR TITLE
Add apkDebugSigningConfig setting

### DIFF
--- a/src/aggregates.scala
+++ b/src/aggregates.scala
@@ -15,6 +15,7 @@ object Aggregate {
                                           instrumentTestRunner: String,
                                           instrumentTestTimeout: Int,
                                           apkbuildDebug: Boolean,
+                                          debugSigningConfig: ApkSigningConfig,
                                           dexMaxHeap: String,
                                           externalDependencyClassPathInTest: Seq[File],
                                           externalDependencyClasspathInCompile: Seq[File],
@@ -23,6 +24,7 @@ object Aggregate {
 
   private[android] case class Apkbuild(packagingOptions: PackagingOptions,
                                        apkbuildDebug: Boolean,
+                                       debugSigningConfig: ApkSigningConfig,
                                        dex: File,
                                        predex: Seq[(File,File)],
                                        collectJni: Seq[File],

--- a/src/keys.scala
+++ b/src/keys.scala
@@ -108,6 +108,8 @@ object Keys {
     "consistent file name for apk output, used for IDE integration") in Android
   val apkSigningConfig = SettingKey[Option[ApkSigningConfig]]("apk-signing-config",
     "signing configuration for release builds") in Android
+  val apkDebugSigningConfig = SettingKey[ApkSigningConfig]("apk-debug-signing-config",
+    "signing configuration for debug builds") in Android
   val signRelease = TaskKey[File]("sign-release", "sign the release build") in Android
   val zipalign = TaskKey[File]("zipalign", "zipalign the final package") in Android
   val packagingOptions = SettingKey[PackagingOptions]("packaging-options",

--- a/src/rules.scala
+++ b/src/rules.scala
@@ -4,6 +4,7 @@ import java.util.Properties
 
 import android.Dependencies.LibraryProject
 import com.android.builder.model.SyncIssue
+import com.android.builder.signing.DefaultSigningConfig
 import com.android.ide.common.process.BaseProcessOutputHandler.BaseProcessOutput
 import com.android.ide.common.process._
 import com.android.tools.lint.LintCliFlags
@@ -13,6 +14,7 @@ import sbt.Keys._
 
 import com.android.builder.core.{LibraryRequest, EvaluationErrorReporter, AndroidBuilder}
 import com.android.builder.sdk.DefaultSdkLoader
+import com.android.ide.common.signing.KeystoreHelper
 import com.android.sdklib.{SdkVersionInfo, AndroidTargetHash, IAndroidTarget, SdkManager}
 import com.android.sdklib.repository.FullRevision
 import com.android.SdkConstants
@@ -585,6 +587,7 @@ object Plugin extends sbt.Plugin {
     apkbuildDebug            := MutableSetting(true),
     apkbuild                <<= apkbuildTaskDef,
     apkbuild                <<= apkbuild dependsOn (managedResources in Compile),
+    apkDebugSigningConfig    := DebugSigningConfig(),
     apkSigningConfig        <<= properties { p =>
       def makeSigningConfig(alias: String, store: String, passwd: String) = {
         val c = PlainSigningConfig(file(store), passwd, alias)


### PR DESCRIPTION
Usage example:

````scala
import android.PlainSigningConfig
import com.android.builder.signing.DefaultSigningConfig._

apkDebugSigningConfig := PlainSigningConfig(
    file( "./debug.keystore" ),
    DEFAULT_PASSWORD,
    DEFAULT_ALIAS
)
````